### PR TITLE
fix: Refund uses price_at_purchase instead of current product price

### DIFF
--- a/services.py
+++ b/services.py
@@ -175,16 +175,16 @@ def process_refund(db: Session, order_id: int) -> dict:
     if order.status == "refunded":
         raise ValueError("Order already refunded")
 
-    # Calculate refund by looking up each product's current price
-    refund_amount = 0.0
+    # Use the stored order.total - the amount the customer actually paid
+    refund_amount = order.total
+
+    # Restore stock for each item
     for item in order.items:
         product = db.query(Product).filter(Product.id == item.product_id).first()
         if product:
-            refund_amount += product.price * item.quantity
-            # Restore stock
             product.stock += item.quantity
 
-    # Deduct loyalty points
+    # Deduct loyalty points based on actual refund amount
     customer = order.customer
     customer.loyalty_points -= int(refund_amount)
     if customer.loyalty_points < 0:
@@ -207,4 +207,3 @@ def process_refund(db: Session, order_id: int) -> dict:
         "refund_amount": round(refund_amount, 2),
         "status": "refunded",
     }
-

--- a/tests/test_refund.py
+++ b/tests/test_refund.py
@@ -1,0 +1,163 @@
+"""
+Tests for refund processing to ensure correct refund amounts.
+"""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from models import Base, Product, Customer, Order, OrderItem, PromoCode
+from services import place_order, process_refund
+
+
+@pytest.fixture
+def db_session():
+    """Create an in-memory SQLite database for testing."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    session = TestingSessionLocal()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def sample_data(db_session):
+    """Set up sample products, customers, and promo codes."""
+    product = Product(name="Test Product", description="A test product", price=100.00, stock=10)
+    customer = Customer(name="Test Customer", email="test@example.com", loyalty_points=0, loyalty_tier="bronze")
+    promo = PromoCode(code="SAVE20", discount_percent=20.0, is_active=True, min_order_amount=0.0)
+    
+    db_session.add_all([product, customer, promo])
+    db_session.commit()
+    db_session.refresh(product)
+    db_session.refresh(customer)
+    db_session.refresh(promo)
+    
+    return {"product": product, "customer": customer, "promo": promo}
+
+
+def test_refund_uses_order_total(db_session, sample_data):
+    """Test that refund amount equals the order.total (what customer paid)."""
+    product = sample_data["product"]
+    customer = sample_data["customer"]
+    
+    # Place an order
+    order = place_order(
+        db=db_session,
+        customer_id=customer.id,
+        items=[{"product_id": product.id, "quantity": 1}],
+    )
+    
+    # Verify order total
+    assert order.total == 100.00
+    
+    # Process refund
+    result = process_refund(db=db_session, order_id=order.id)
+    
+    # Refund should equal order.total
+    assert result["refund_amount"] == 100.00
+    assert result["status"] == "refunded"
+
+
+def test_refund_ignores_price_changes_after_purchase(db_session, sample_data):
+    """Test that refund uses price at purchase, not current price."""
+    product = sample_data["product"]
+    customer = sample_data["customer"]
+    
+    original_price = product.price  # 100.00
+    
+    # Place an order at original price
+    order = place_order(
+        db=db_session,
+        customer_id=customer.id,
+        items=[{"product_id": product.id, "quantity": 2}],
+    )
+    
+    # Order total should be 2 * 100 = 200
+    assert order.total == 200.00
+    
+    # Simulate price change after purchase
+    product.price = 150.00
+    db_session.commit()
+    
+    # Process refund
+    result = process_refund(db=db_session, order_id=order.id)
+    
+    # Refund should still be 200.00 (what customer paid), NOT 300.00 (new price * quantity)
+    assert result["refund_amount"] == 200.00
+
+
+def test_refund_includes_discounts_applied(db_session, sample_data):
+    """Test that refund amount reflects discounts applied at checkout."""
+    product = sample_data["product"]
+    customer = sample_data["customer"]
+    
+    # Place an order with 20% promo code
+    order = place_order(
+        db=db_session,
+        customer_id=customer.id,
+        items=[{"product_id": product.id, "quantity": 1}],
+        promo_code_str="SAVE20",
+    )
+    
+    # Order total should be 100 - 20% = 80.00
+    assert order.total == 80.00
+    assert order.discount_amount == 20.00
+    
+    # Process refund
+    result = process_refund(db=db_session, order_id=order.id)
+    
+    # Refund should be 80.00 (discounted amount), NOT 100.00 (full price)
+    assert result["refund_amount"] == 80.00
+
+
+def test_refund_restores_stock(db_session, sample_data):
+    """Test that refund restores product stock."""
+    product = sample_data["product"]
+    customer = sample_data["customer"]
+    
+    initial_stock = product.stock  # 10
+    
+    # Place an order for 3 items
+    order = place_order(
+        db=db_session,
+        customer_id=customer.id,
+        items=[{"product_id": product.id, "quantity": 3}],
+    )
+    
+    # Stock should be reduced
+    db_session.refresh(product)
+    assert product.stock == initial_stock - 3  # 7
+    
+    # Process refund
+    process_refund(db=db_session, order_id=order.id)
+    
+    # Stock should be restored
+    db_session.refresh(product)
+    assert product.stock == initial_stock  # 10
+
+
+def test_refund_already_refunded_order_raises_error(db_session, sample_data):
+    """Test that refunding an already refunded order raises an error."""
+    product = sample_data["product"]
+    customer = sample_data["customer"]
+    
+    order = place_order(
+        db=db_session,
+        customer_id=customer.id,
+        items=[{"product_id": product.id, "quantity": 1}],
+    )
+    
+    # First refund should succeed
+    process_refund(db=db_session, order_id=order.id)
+    
+    # Second refund should fail
+    with pytest.raises(ValueError, match="Order already refunded"):
+        process_refund(db=db_session, order_id=order.id)
+
+
+def test_refund_nonexistent_order_raises_error(db_session):
+    """Test that refunding a non-existent order raises an error."""
+    with pytest.raises(ValueError, match="Order not found"):
+        process_refund(db=db_session, order_id=99999)


### PR DESCRIPTION
## Summary

Fixes a critical bug where refund calculations used current product prices instead of the price customers actually paid at purchase time.

## Problem

The `process_refund` function in `services.py` was querying the `Product` table for current prices and calculating refunds based on those values. This caused:
- Over-refunds when prices increased since purchase
- Under-refunds when prices decreased since purchase
- Complete disregard for any discounts (promo codes, loyalty discounts) applied at checkout

Example from logs: Customer paid $63.99 (with WELCOME20 promo) but was refunded $79.99 (current product price × quantity).

## Solution

Modified `process_refund` to use `order.total` directly, which represents the exact amount the customer paid. This:
- Correctly accounts for price_at_purchase
- Includes any discounts that were applied
- Matches the documented business rule in the function's docstring

Also updated loyalty points deduction to use the correct refund amount.

## Testing

Added unit tests covering:
- Basic refund using order.total
- Refund correctness when product price changes after purchase
- Refund correctness when promo codes were applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed refund calculation to use the original purchase amount instead of recalculating from current prices, ensuring refunds remain accurate even after price changes.
  * Improved refund processing to properly reflect applied discounts.

* **Tests**
  * Added comprehensive test coverage for refund scenarios, including edge cases and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->